### PR TITLE
Implement a generic variant of the lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nonparallel"
-version = "0.1.0"
-authors = ["Danilo Bargen <mail@dbrgn.ch>"]
+version = "0.2.0"
+authors = ["Danilo Bargen <mail@dbrgn.ch>", "MOZGIII <mike-n@narod.ru>"]
 documentation = "https://docs.rs/nonparallel/"
 repository = "https://github.com/dbrgn/nonparallel/"
 license = "MIT OR Apache-2.0"
@@ -27,3 +27,4 @@ quote = "1"
 
 [dev-dependencies]
 lazy_static = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "parking_lot"] }

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2019 Danilo Bargen
+Copyright (c) 2022 MOZGIII
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -22,26 +22,25 @@ static mutex reference must be passed to the `nonparallel` annotation.
 
 ```rust
 use std::sync::Mutex;
-use lazy_static::lazy_static;
 use nonparallel::nonparallel;
 
 // Create two locks
-lazy_static! { static ref MUT_A: Mutex<()> = Mutex::new(()); }
-lazy_static! { static ref MUT_B: Mutex<()> = Mutex::new(()); }
+static MUT_A: Mutex<()> = Mutex::new(());
+static MUT_B: Mutex<()> = Mutex::new(());
 
 // Mutually exclude parallel runs of functions using those two locks
 
-#[nonparallel(MUT_A)]
+#[nonparallel(MUT_A.lock().unwrap())]
 fn function_a1() {
     // This will not run in parallel to function_a2
 }
 
-#[nonparallel(MUT_A)]
+#[nonparallel(MUT_A.lock().unwrap())]
 fn function_a2() {
     // This will not run in parallel to function_a1
 }
 
-#[nonparallel(MUT_B)]
+#[nonparallel(MUT_B.lock().unwrap())]
 fn function_b() {
     // This may run in parallel to function_a*
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,21 +9,21 @@ lazy_static! { static ref MUT_B: Mutex<()> = Mutex::new(()); }
 
 const COUNT: usize = 1_000;
 
-#[nonparallel(MUT_A)]
+#[nonparallel(MUT_A.lock().unwrap())]
 fn append1(vec: Arc<Mutex<Vec<u32>>>) {
     for _ in 0..COUNT {
         vec.lock().unwrap().push(1);
     }
 }
 
-#[nonparallel(MUT_A)]
+#[nonparallel(MUT_A.lock().unwrap())]
 fn append2(vec: Arc<Mutex<Vec<u32>>>) {
     for _ in 0..COUNT {
         vec.lock().unwrap().push(2);
     }
 }
 
-#[nonparallel(MUT_A)]
+#[nonparallel(MUT_A.lock().unwrap())]
 fn append3(vec: Arc<Mutex<Vec<u32>>>) {
     for _ in 0..COUNT {
         vec.lock().unwrap().push(3);

--- a/tests/tokio-macros.rs
+++ b/tests/tokio-macros.rs
@@ -1,0 +1,20 @@
+use nonparallel::nonparallel;
+use tokio::sync::Mutex;
+
+static MUT_A: Mutex<()> = Mutex::const_new(());
+
+/// This test executes inside the runtime and the async wrapping,
+/// and thus it can do `.await`.
+/// The downside is runtime will be executing even after the mutex is unlocked,
+/// which is not sound, as things that were inteded to be under the mutex can
+/// still be executing until the runtime shuts down.
+#[nonparallel(MUT_A.lock().await)]
+#[tokio::test]
+async fn inside_rt() {}
+
+/// This test executes around the runtime and can't do `.await`. It must call
+/// the `blocking_lock()` instead.
+/// However, it is guaranteed to properly lock the runtime.
+#[tokio::test]
+#[nonparallel(MUT_A.blocking_lock())]
+async fn around_rt() {}


### PR DESCRIPTION
This breaks the API, but this create is pre-1.0 so we're good.

I need this cause I want to use it with `tokio::test` and async mutexes.